### PR TITLE
Update es.po and correct one translation

### DIFF
--- a/po/es.po
+++ b/po/es.po
@@ -934,7 +934,7 @@ msgstr "Hay datos que deben ser escritos en el dispositivo «%s» antes de que p
 
 #: ../src/xfdesktop-notify.c:221
 msgid "Unmount Finished"
-msgstr "Desmontaje sin terminar"
+msgstr "Desmontaje terminado"
 
 #: ../src/xfdesktop-notify.c:223 ../src/xfdesktop-notify.c:408
 #, c-format


### PR DESCRIPTION
The English popup title "Unmount Finished" should be translated to Spanish as "Desmontaje terminado" (and not as "Desmontaje sin terminar", as it is now, since "Desmontaje sin terminar" means just the opposite ("Unmount UNfinished").